### PR TITLE
Fixed Stand contact damage bug and Vampire life steal logic

### DIFF
--- a/Items/Vampire/VampirePlayerClass.cs
+++ b/Items/Vampire/VampirePlayerClass.cs
@@ -231,11 +231,11 @@ namespace JoJoStands.Items.Vampire
                         {
                             buriedUndergroundHealthRegenTimer = 0;
 
-                            int healthRegained = (int)(Player.statLifeMax * (0.04f * GetSkillLevel(UndergroundRecovery)));
-                            if (Player.statLife + healthRegained <= Player.statLifeMax)
+                            int healthRegained = (int)(Player.statLifeMax2 * (0.04f * GetSkillLevel(UndergroundRecovery)));
+                            if (Player.statLife + healthRegained <= Player.statLifeMax2)
                                 Player.statLife += healthRegained;
                             else
-                                Player.statLife = Player.statLifeMax;
+                                Player.statLife = Player.statLifeMax2;
                             Player.HealEffect(healthRegained);
                         }
                         Player.controlUseItem = false;
@@ -285,14 +285,14 @@ namespace JoJoStands.Items.Vampire
                 if (calculatedLifeSteal < 0)
                     return;
 
-                if (calculatedLifeSteal < Player.statLifeMax - Player.statLife)
+                if (calculatedLifeSteal < Player.statLifeMax2 - Player.statLife)
                 {
                     Player.statLife += calculatedLifeSteal;
                     Player.HealEffect(calculatedLifeSteal, true);
                 }
-                if (calculatedLifeSteal >= Player.statLifeMax - Player.statLife)
+                if (calculatedLifeSteal >= Player.statLifeMax2 - Player.statLife)
                 {
-                    calculatedLifeSteal = Player.statLifeMax - Player.statLife;
+                    calculatedLifeSteal = Player.statLifeMax2 - Player.statLife;
                     Player.statLife += (int)(calculatedLifeSteal);
                     Player.HealEffect(calculatedLifeSteal, true);
                 }
@@ -327,14 +327,14 @@ namespace JoJoStands.Items.Vampire
                 if (calculatedLifeSteal < 0)
                     return;
 
-                if (calculatedLifeSteal < Player.statLifeMax - Player.statLife)
+                if (calculatedLifeSteal < Player.statLifeMax2 - Player.statLife)
                 {
                     Player.statLife += calculatedLifeSteal;
                     Player.HealEffect(calculatedLifeSteal, true);
                 }
-                if (calculatedLifeSteal >= Player.statLifeMax - Player.statLife)
+                if (calculatedLifeSteal >= Player.statLifeMax2 - Player.statLife)
                 {
-                    calculatedLifeSteal = Player.statLifeMax - Player.statLife;
+                    calculatedLifeSteal = Player.statLifeMax2 - Player.statLife;
                     Player.statLife += (int)(calculatedLifeSteal);
                     Player.HealEffect(calculatedLifeSteal, true);
                 }
@@ -569,7 +569,7 @@ namespace JoJoStands.Items.Vampire
                 if (Main.rand.Next(0, 100 + 1) <= 30)
                 {
                     Player.AddBuff(ModContent.BuffType<FinalPush>(), 2 * 60 * 60);
-                    Player.statLife = (int)(Player.statLifeMax * 0.3f);
+                    Player.statLife = (int)(Player.statLifeMax2 * 0.3f);
                     return false;
                 }
             }

--- a/Projectiles/PlayerStands/StandClass.cs
+++ b/Projectiles/PlayerStands/StandClass.cs
@@ -40,7 +40,28 @@ namespace JoJoStands.Projectiles.PlayerStands
         /// </summary>
         public virtual void ExtraSetDefaults()
         { }
+        
+        public override bool PreAI()
+        {
+            // Forces the penetration to -1 (infinite penetration).
+            // This prevents the Stand projectile from being deleted by the system when it touches an enemy due to penetration loss.
+            Projectile.penetrate = -1; 
+            return true; // Return true to allow the AI logic to continue.
+        }
+        
+        // This method determines whether the projectile can hit an NPC.
+        public override bool? CanHitNPC(NPC target)
+        {
+            // Return false directly.
+            // This means the "Stand Body" projectile will never deal contact damage to enemies.         
+            return false; 
+        }
 
+        // If the mod has PvP logic, it is best to disable PvP contact damage as well.
+        public override bool CanHitPvp(Player target)
+        {
+            return false;
+        }
         public override string Texture => Mod.Name + "/Extras/EmptyTexture";
         /// <summary>
         /// How fast the projectile the Stand shoots goes. Usually at 16f.


### PR DESCRIPTION
Hello,

I've fixed two bugs that I encountered during gameplay:

1. **Vampire Life Steal Logic**:
Changed `Player.statLifeMax` to `Player.statLifeMax2` in the Vampire life steal logic. Previously, it ignored max health increases from buffs (like Aja Stone), preventing the player from healing to full health.

2. **Stand Projectile Glitch**:
Fixed an issue where the Stand projectile would instantly despawn and deal unintentionally high contact damage when colliding with an NPC.
I overrode `PreAI` (to force infinite penetration), `CanHitNPC` (to disable contact damage), and `CanHitPvp` in `StandClass.cs`.

I hope these fixes help!